### PR TITLE
PAYLAPMEXT-286: Ajout identifiant commercant

### DIFF
--- a/src/main/java/com/payline/payment/equens/service/GenericPaymentService.java
+++ b/src/main/java/com/payline/payment/equens/service/GenericPaymentService.java
@@ -234,12 +234,15 @@ public class GenericPaymentService {
             deliveryAddress = buildAddress(paymentRequest.getBuyer().getAddressForType(Buyer.AddressType.DELIVERY));
         }
 
+        String softDescriptor = paymentRequest.getSoftDescriptor();
+        String pispContract = paymentRequest.getContractConfiguration().getProperty(Constants.ContractConfigurationKeys.PISP_CONTRACT).getValue();
+
         PaymentInitiationRequest.PaymentInitiationRequestBuilder paymentInitiationRequestBuilder = new PaymentInitiationRequest.PaymentInitiationRequestBuilder()
                 .withAspspId(aspspId)
                 .withEndToEndId(paymentRequest.getTransactionId())
                 .withInitiatingPartyReferenceId(paymentRequest.getOrder().getReference())
                 .withInitiatingPartyReturnUrl(paymentRequest.getEnvironment().getRedirectionReturnURL())
-                .withRemittanceInformation(paymentRequest.getSoftDescriptor())
+                .withRemittanceInformation(softDescriptor + pispContract)
                 .withRemittanceInformationStructured(
                         new RemittanceInformationStructured.RemittanceInformationStructuredBuilder()
                                 .withReference(paymentRequest.getOrder().getReference())

--- a/src/main/java/com/payline/payment/equens/service/impl/ConfigurationServiceImpl.java
+++ b/src/main/java/com/payline/payment/equens/service/impl/ConfigurationServiceImpl.java
@@ -143,6 +143,9 @@ public class ConfigurationServiceImpl implements ConfigurationService {
         countryCode.put(CountryCode.ALL.name(), i18n.getMessage("countryCode.all", locale));
         parameters.add(this.newListBoxParameter(Constants.ContractConfigurationKeys.COUNTRIES, countryCode, CountryCode.ALL.name(), true, locale));
 
+        // PISP contract
+        parameters.add(this.newInputParameter(Constants.ContractConfigurationKeys.PISP_CONTRACT, true, locale));
+
         return parameters;
     }
 
@@ -159,6 +162,15 @@ public class ConfigurationServiceImpl implements ConfigurationService {
                 String message = i18n.getMessage(I18N_CONTRACT_PREFIX + param.getKey() + ".requiredError", locale);
                 errors.put(param.getKey(), message);
             }
+        }
+
+        // check PISP format (N12)
+        String pispContract = accountInfo.get(Constants.ContractConfigurationKeys.PISP_CONTRACT);
+        if (PluginUtils.isEmpty(pispContract)
+                || pispContract.length() != 12
+                || !PluginUtils.isNumeric(pispContract)) {
+            String message = i18n.getMessage(I18N_CONTRACT_PREFIX + Constants.ContractConfigurationKeys.PISP_CONTRACT + ".badFormat", locale);
+            errors.put(Constants.ContractConfigurationKeys.PISP_CONTRACT, message);
         }
 
         // Check the clientName and onboarding ID

--- a/src/main/java/com/payline/payment/equens/utils/Constants.java
+++ b/src/main/java/com/payline/payment/equens/utils/Constants.java
@@ -19,6 +19,7 @@ public class Constants {
         public static final String PURPOSE_CODE = "purposeCode";
         public static final String SCA_METHOD = "scaMethod";
         public static final String COUNTRIES = "countries";
+        public static final String PISP_CONTRACT = "pisp";
 
         /* Static utility class : no need to instantiate it (Sonar bug fix) */
         private ContractConfigurationKeys(){}

--- a/src/main/java/com/payline/payment/equens/utils/PluginUtils.java
+++ b/src/main/java/com/payline/payment/equens/utils/PluginUtils.java
@@ -95,6 +95,21 @@ public class PluginUtils {
         return (s == null || s.length() == 0);
     }
 
+    public static boolean isNumeric(String s) {
+        boolean b = true;
+        if (isEmpty(s)) {
+            b = false;
+        } else {
+            try {
+                Double.parseDouble(s);
+            } catch (NumberFormatException e) {
+                b = false;
+            }
+        }
+        return b;
+    }
+
+
     /**
      * Try to find in aspsps list an aspsp with the given BIC11
      * if no aspsp found, try again by truncating the BIC11 into a BIC8
@@ -151,13 +166,13 @@ public class PluginUtils {
             throw new InvalidDataException("the list of Aspsps is empty");
         }
 
-        String countryCode = checkBICFromListAspsps(listAspsps,bic,false);
+        String countryCode = checkBICFromListAspsps(listAspsps, bic, false);
 
-        if(countryCode == null){
-            countryCode = checkBICFromListAspsps(listAspsps,bic, true);
+        if (countryCode == null) {
+            countryCode = checkBICFromListAspsps(listAspsps, bic, true);
         }
 
-        if(countryCode != null){
+        if (countryCode != null) {
             return countryCode;
         }
 
@@ -169,13 +184,14 @@ public class PluginUtils {
      * Check if a BIC is present in the Aspsps list. The CheckOnlyEightFirstsCharacters allow you to choose how the BIC check will be done.
      * - FALSE: The raw values will be checked.
      * - TRUE : The 8 first characters will be checked.
-     * @param listAspsps The list of aspsp
-     * @param bic The BIC to find
+     *
+     * @param listAspsps                     The list of aspsp
+     * @param bic                            The BIC to find
      * @param checkOnlyEightFirstsCharacters The check to do
      * @return
      */
     public static String checkBICFromListAspsps(List<Aspsp> listAspsps, String bic, boolean checkOnlyEightFirstsCharacters) {
-        final String bicToCompare = checkOnlyEightFirstsCharacters ? bic.substring(0,8) : bic;
+        final String bicToCompare = checkOnlyEightFirstsCharacters ? bic.substring(0, 8) : bic;
         String countryCode = null;
 
         for (Aspsp aspsp : listAspsps) {

--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -36,6 +36,11 @@ contract.countries.label=
 contract.countries.description=
 contract.countries.requiredError=
 
+contract.pisp.label=
+contract.pisp.description=
+contract.pisp.requiredError=
+contract.pisp.badFormat=
+
 countryCode.fr=
 countryCode.es=
 countryCode.all=

--- a/src/main/resources/messages_en.properties
+++ b/src/main/resources/messages_en.properties
@@ -36,6 +36,11 @@ contract.countries.label=
 contract.countries.description=
 contract.countries.requiredError=
 
+contract.pisp.label=
+contract.pisp.description=
+contract.pisp.requiredError=
+contract.pisp.badFormat=
+
 countryCode.fr=
 countryCode.es=
 countryCode.all=

--- a/src/main/resources/messages_fr.properties
+++ b/src/main/resources/messages_fr.properties
@@ -37,6 +37,11 @@ contract.countries.label=Code Pays accept\u00e9 par le commer\u00e7ant
 contract.countries.description=Code Pays accept\u00e9 par le commer\u00e7ant
 contract.countries.requiredError=Au moins un code pays est obligatoire
 
+contract.pisp.label=R\u00e9f\u00e9rence contrat PISP Market Pay
+contract.pisp.description=
+contract.pisp.requiredError=Veuillez renseigner la r\u00e9f\u00e9rence contrat PISP
+contract.pisp.badFormat=la r\u00e9f\u00e9rence contrat PISP doit contenir uniquement 12 chiffres
+
 countryCode.fr=FRANCE
 countryCode.es=ESPAGNE
 countryCode.all=TOUS

--- a/src/test/java/com/payline/payment/equens/MockUtils.java
+++ b/src/test/java/com/payline/payment/equens/MockUtils.java
@@ -161,6 +161,8 @@ public class MockUtils {
                 new ContractProperty(ConfigurationServiceImpl.PurposeCode.COMMERCE.getCode()));
         contractProperties.put(Constants.ContractConfigurationKeys.COUNTRIES,
                 new ContractProperty(exampleCountry));
+        contractProperties.put(Constants.ContractConfigurationKeys.PISP_CONTRACT,
+                new ContractProperty("123456789012"));
 
         return new ContractConfiguration("INST EquensWorldline", contractProperties);
     }
@@ -354,7 +356,7 @@ public class MockUtils {
                 .withEndToEndId( "PAYLINE" + timestamp )
                 .withInitiatingPartyReferenceId( "REF" + timestamp )
                 .withInitiatingPartyReturnUrl( "http://redirectionURL.com" )
-                .withRemittanceInformation( "softDescriptor" )
+                .withRemittanceInformation( "softDescriptor123456789012" )
                 .withRemittanceInformationStructured(
                         new RemittanceInformationStructured.RemittanceInformationStructuredBuilder()
                                 .withReference("REF" + timestamp)

--- a/src/test/java/com/payline/payment/equens/utils/PluginUtilsTest.java
+++ b/src/test/java/com/payline/payment/equens/utils/PluginUtilsTest.java
@@ -67,6 +67,14 @@ class PluginUtilsTest {
         assertNull(PluginUtils.truncate(null, 30));
     }
 
+    @Test
+    void isNumeric(){
+        Assertions.assertFalse(PluginUtils.isNumeric(null));
+        Assertions.assertFalse(PluginUtils.isNumeric(""));
+        Assertions.assertTrue(PluginUtils.isNumeric("1"));
+        Assertions.assertTrue(PluginUtils.isNumeric("123456789012"));
+    }
+
 
     @Test
     void getAspspIdFromBIC() {


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/41673610/95560437-924e5780-0a19-11eb-9e3b-49c83dd70925.png)

La vulnérabilité vient du chiffrement RSA utilisé pour chiffrer les pluginConf

les partnerConf n'ont pas changé