### PR TITLE
Paylapmext 296: changement du controle du champs pispContract

### DIFF
--- a/src/main/java/com/payline/payment/equens/service/impl/ConfigurationServiceImpl.java
+++ b/src/main/java/com/payline/payment/equens/service/impl/ConfigurationServiceImpl.java
@@ -166,9 +166,7 @@ public class ConfigurationServiceImpl implements ConfigurationService {
 
         // check PISP format (N12)
         String pispContract = accountInfo.get(Constants.ContractConfigurationKeys.PISP_CONTRACT);
-        if (PluginUtils.isEmpty(pispContract)
-                || pispContract.length() != 12
-                || !PluginUtils.isNumeric(pispContract)) {
+        if (PluginUtils.isEmpty(pispContract) ||  pispContract.length() > 12) {
             String message = i18n.getMessage(I18N_CONTRACT_PREFIX + Constants.ContractConfigurationKeys.PISP_CONTRACT + ".badFormat", locale);
             errors.put(Constants.ContractConfigurationKeys.PISP_CONTRACT, message);
         }

--- a/src/main/java/com/payline/payment/equens/service/impl/ConfigurationServiceImpl.java
+++ b/src/main/java/com/payline/payment/equens/service/impl/ConfigurationServiceImpl.java
@@ -166,7 +166,7 @@ public class ConfigurationServiceImpl implements ConfigurationService {
 
         // check PISP format (N12)
         String pispContract = accountInfo.get(Constants.ContractConfigurationKeys.PISP_CONTRACT);
-        if (PluginUtils.isEmpty(pispContract) ||  pispContract.length() > 12) {
+        if (PluginUtils.isEmpty(pispContract) ||  pispContract.length() > 12  || !PluginUtils.isNumeric(pispContract)) {
             String message = i18n.getMessage(I18N_CONTRACT_PREFIX + Constants.ContractConfigurationKeys.PISP_CONTRACT + ".badFormat", locale);
             errors.put(Constants.ContractConfigurationKeys.PISP_CONTRACT, message);
         }


### PR DESCRIPTION
Les partnerConf ne changent pas

![image](https://user-images.githubusercontent.com/41673610/97277649-0752c700-1839-11eb-9c94-a15402b26e3c.png)
