### PR TITLE
PAYLAPMEXT-294: Consolidation du filtrage des banques

### DIFF
--- a/src/main/java/com/payline/payment/equens/bean/business/reachdirectory/Detail.java
+++ b/src/main/java/com/payline/payment/equens/bean/business/reachdirectory/Detail.java
@@ -26,6 +26,7 @@ public class Detail {
     public Detail(String api, String fieldName,String type, String value, String protocolVersion) {
         this.api = api;
         this.fieldName = fieldName;
+        this.type = type;
         this.value = value;
         this.protocolVersion = protocolVersion;
     }

--- a/src/main/java/com/payline/payment/equens/bean/business/reachdirectory/Detail.java
+++ b/src/main/java/com/payline/payment/equens/bean/business/reachdirectory/Detail.java
@@ -2,6 +2,7 @@ package com.payline.payment.equens.bean.business.reachdirectory;
 
 import com.google.gson.annotations.SerializedName;
 
+
 public class Detail {
 
     @SerializedName("Api")
@@ -10,11 +11,24 @@ public class Detail {
     @SerializedName("FieldName")
     private String fieldName;
 
+    @SerializedName("Type")
+    private String type;
+
     @SerializedName("Value")
     private String value;
 
     @SerializedName("ProtocolVersion")
     private String protocolVersion;
+
+    public Detail() {
+    }
+
+    public Detail(String api, String fieldName,String type, String value, String protocolVersion) {
+        this.api = api;
+        this.fieldName = fieldName;
+        this.value = value;
+        this.protocolVersion = protocolVersion;
+    }
 
     public String getApi() {
         return api;
@@ -32,3 +46,4 @@ public class Detail {
         return protocolVersion;
     }
 }
+

--- a/src/main/java/com/payline/payment/equens/service/impl/PaymentFormConfigurationServiceImpl.java
+++ b/src/main/java/com/payline/payment/equens/service/impl/PaymentFormConfigurationServiceImpl.java
@@ -110,12 +110,7 @@ public class PaymentFormConfigurationServiceImpl extends LogoPaymentFormConfigur
                 .filter(e -> e.getCountryCode() != null)
                 .filter(e -> listCountryCode.isEmpty() || listCountryCode.contains(e.getCountryCode()))
                 .filter(e -> !PluginUtils.isEmpty(e.getBic()))
-                .filter(e -> {
-                    if (e.getDetails() != null) {
-                        return isCompatible(e.getDetails());
-                    }
-                    return true;
-                })
+                .filter(e -> isCompatible(e.getDetails()))
                 .collect(Collectors.toList());
     }
 
@@ -133,26 +128,22 @@ public class PaymentFormConfigurationServiceImpl extends LogoPaymentFormConfigur
     }
 
     /**
-     * Check if a bank is compatible with the Normal paymentMode
+     * Check if a bank is compatible with the Instant paymentMode
      * see PAYLAPMEXT-294
      *
      * @param details
      * @return true if compatible or no info
      */
     public boolean isCompatible(List<Detail> details) {
-        boolean containInstant = false;
-        boolean containNormal = false;
+        boolean isCompatible = true;
 
-        for (Detail detail : details) {
-            if ("PaymentProduct".equalsIgnoreCase(detail.getFieldName()) && detail.getValue() != null) {
-                if (detail.getValue().contains("Normal")) {
-                    containNormal = true;
-                }
-                if (detail.getValue().contains("Instant")) {
-                    containInstant = true;
+        if(details != null){
+            for (Detail detail : details) {
+                if ("PaymentProduct".equalsIgnoreCase(detail.getFieldName()) && detail.getValue() != null && !detail.getValue().contains("Instant") && !detail.getValue().isEmpty()) {
+                    isCompatible = false;
                 }
             }
         }
-        return containInstant || !containNormal;
+        return isCompatible;
     }
 }

--- a/src/main/java/com/payline/payment/equens/service/impl/PaymentFormConfigurationServiceImpl.java
+++ b/src/main/java/com/payline/payment/equens/service/impl/PaymentFormConfigurationServiceImpl.java
@@ -139,8 +139,9 @@ public class PaymentFormConfigurationServiceImpl extends LogoPaymentFormConfigur
 
         if(details != null){
             for (Detail detail : details) {
-                if ("PaymentProduct".equalsIgnoreCase(detail.getFieldName()) && detail.getValue() != null && !detail.getValue().contains("Instant") && !detail.getValue().isEmpty()) {
+                if ( !PluginUtils.isEmpty(detail.getValue()) && "PaymentProduct".equalsIgnoreCase(detail.getFieldName()) && !detail.getValue().contains("Instant")) {
                     isCompatible = false;
+                    break;
                 }
             }
         }

--- a/src/main/java/com/payline/payment/equens/service/impl/PaymentFormConfigurationServiceImpl.java
+++ b/src/main/java/com/payline/payment/equens/service/impl/PaymentFormConfigurationServiceImpl.java
@@ -112,13 +112,7 @@ public class PaymentFormConfigurationServiceImpl extends LogoPaymentFormConfigur
                 .filter(e -> !PluginUtils.isEmpty(e.getBic()))
                 .filter(e -> {
                     if (e.getDetails() != null) {
-                        for (Detail e2 : e.getDetails()) {
-                            if ("POST /payments".equals(e2.getApi())
-                                    && (e2.getValue() == null || e2.getValue().contains("Instant"))) {
-                                return true;
-                            }
-                        }
-                        return false;
+                        return isCompatible(e.getDetails());
                     }
                     return true;
                 })
@@ -136,5 +130,29 @@ public class PaymentFormConfigurationServiceImpl extends LogoPaymentFormConfigur
                 .withKey(aspsp.getBic())
                 .withValue(valuesBuilder.toString())
                 .build();
+    }
+
+    /**
+     * Check if a bank is compatible with the Normal paymentMode
+     * see PAYLAPMEXT-294
+     *
+     * @param details
+     * @return true if compatible or no info
+     */
+    public boolean isCompatible(List<Detail> details) {
+        boolean containInstant = false;
+        boolean containNormal = false;
+
+        for (Detail detail : details) {
+            if ("PaymentProduct".equalsIgnoreCase(detail.getFieldName()) && detail.getValue() != null) {
+                if (detail.getValue().contains("Normal")) {
+                    containNormal = true;
+                }
+                if (detail.getValue().contains("Instant")) {
+                    containInstant = true;
+                }
+            }
+        }
+        return containInstant || !containNormal;
     }
 }

--- a/src/test/java/com/payline/payment/equens/service/impl/PaymentFormConfigurationServiceImplTest.java
+++ b/src/test/java/com/payline/payment/equens/service/impl/PaymentFormConfigurationServiceImplTest.java
@@ -1,6 +1,7 @@
 package com.payline.payment.equens.service.impl;
 
 import com.payline.payment.equens.MockUtils;
+import com.payline.payment.equens.bean.business.reachdirectory.Detail;
 import com.payline.payment.equens.utils.i18n.I18nService;
 import com.payline.pmapi.bean.common.FailureCause;
 import com.payline.pmapi.bean.paymentform.bean.field.SelectOption;
@@ -10,6 +11,7 @@ import com.payline.pmapi.bean.paymentform.request.PaymentFormConfigurationReques
 import com.payline.pmapi.bean.paymentform.response.configuration.PaymentFormConfigurationResponse;
 import com.payline.pmapi.bean.paymentform.response.configuration.impl.PaymentFormConfigurationResponseFailure;
 import com.payline.pmapi.bean.paymentform.response.configuration.impl.PaymentFormConfigurationResponseSpecific;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.InjectMocks;
@@ -148,5 +150,44 @@ class PaymentFormConfigurationServiceImplTest {
 
         // then: there is 2 banks choice at the end
         assertEquals(4, result.size());
+    }
+
+    @Test
+    void isCompatibleNormal(){
+        List<Detail> details = new ArrayList<>();
+        details.add(new Detail("API", "foo", "MANDATORY", null, "protocol1"));
+        details.add(new Detail("API", "PaymentProduct", "SUPPORTED", "Normal", "protocol1"));
+        details.add(new Detail("API", "foo2", "MANDATORY", null, "protocol1"));
+
+        Assertions.assertFalse( service.isCompatible(details));
+    }
+
+    @Test
+    void isCompatibleNormalAndInstant(){
+        List<Detail> details = new ArrayList<>();
+        details.add(new Detail("API", "foo", "MANDATORY", null, "protocol1"));
+        details.add(new Detail("API", "PaymentProduct", "SUPPORTED", "Normal|Instant", "protocol1"));
+        details.add(new Detail("API", "foo2", "MANDATORY", null, "protocol1"));
+
+        Assertions.assertTrue( service.isCompatible(details));
+    }
+
+    @Test
+    void isCompatibleInstant(){
+        List<Detail> details = new ArrayList<>();
+        details.add(new Detail("API", "foo", "MANDATORY", null, "protocol1"));
+        details.add(new Detail("API", "PaymentProduct", "SUPPORTED", "Instant", "protocol1"));
+        details.add(new Detail("API", "foo2", "MANDATORY", null, "protocol1"));
+
+        Assertions.assertTrue( service.isCompatible(details));
+    }
+
+    @Test
+    void isCompatibleNone(){
+        List<Detail> details = new ArrayList<>();
+        details.add(new Detail("API", "foo", "MANDATORY", null, "protocol1"));
+        details.add(new Detail("API", "foo2", "MANDATORY", null, "protocol1"));
+
+        Assertions.assertTrue( service.isCompatible(details));
     }
 }

--- a/src/test/java/com/payline/payment/equens/service/impl/PaymentFormConfigurationServiceImplTest.java
+++ b/src/test/java/com/payline/payment/equens/service/impl/PaymentFormConfigurationServiceImplTest.java
@@ -190,4 +190,9 @@ class PaymentFormConfigurationServiceImplTest {
 
         Assertions.assertTrue( service.isCompatible(details));
     }
+
+    @Test
+    void isCompatibleNull(){
+        Assertions.assertTrue( service.isCompatible(null));
+    }
 }


### PR DESCRIPTION
les configs n'ont pas changé
![image](https://user-images.githubusercontent.com/41673610/97425388-5e789a80-1912-11eb-9327-29db36abcfa0.png)

Je ne sais pas pourquoi la coverage n'apparait pas mais c'est strictement le même que sct-equens (84%)

le codesmell en plus est le champs "type" des details qui n'est pas utilisé pour l'instant