### PR TITLE
PAYLMPT-16

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 description = payment-method-equens
 group = com.payline.payment.equens
-version = 1.6-SNAPSHOT
+version = 1.7-SNAPSHOT
 
 paymentMethodApiVersion = 1.13-SNAPSHOT
 gsonVersion = 2.8.5

--- a/src/main/java/com/payline/payment/equens/business/BankBusiness.java
+++ b/src/main/java/com/payline/payment/equens/business/BankBusiness.java
@@ -13,4 +13,6 @@ public interface BankBusiness {
     String getPrefixBic(String bic);
 
     Aspsp convertToAspsp(String label, BankAffiliation bankAffiliation);
+
+    boolean isIbanRequired(Aspsp aspsp);
 }

--- a/src/main/java/com/payline/payment/equens/business/impl/BankBusinessImpl.java
+++ b/src/main/java/com/payline/payment/equens/business/impl/BankBusinessImpl.java
@@ -14,6 +14,8 @@ import java.util.Map;
 public class BankBusinessImpl implements BankBusiness {
 
     private static final String PAYMENT_PRODUCT_FIELD_NAME = "PaymentProduct";
+    private static final String DEBTOR_ACCOUNT_FIELD_NAME = "DebtorAccount";
+    private static final String MANDATORY = "MANDATORY";
     private static final String SUPPORTED_TYPE = "SUPPORTED";
     private static final String POST_PAYMENTS_API = "POST /payments";
 
@@ -44,6 +46,28 @@ public class BankBusinessImpl implements BankBusiness {
             }
         }
         return compatibilityMap.get(paymentMode);
+    }
+
+    /**
+     * Methode permettant de determiner si la banque demande un iban pour le paiement ou non.
+     * @param aspsp
+     *      Les informations de la banque
+     * @return
+     *      true si l'iban est obligatoire false sinon.
+     */
+    public boolean isIbanRequired(final Aspsp aspsp) {
+        boolean isRequired = false;
+        if (aspsp.getDetails() != null) {
+            for (Detail detail : aspsp.getDetails()) {
+                if (DEBTOR_ACCOUNT_FIELD_NAME.equals(detail.getFieldName())
+                        && POST_PAYMENTS_API.equals(detail.getApi())
+                        && MANDATORY.equals(detail.getType())) {
+                    isRequired = true;
+                    break;
+                }
+            }
+        }
+        return isRequired;
     }
 
     @Override

--- a/src/main/java/com/payline/payment/equens/service/BankService.java
+++ b/src/main/java/com/payline/payment/equens/service/BankService.java
@@ -139,6 +139,14 @@ public class BankService {
         return aspspList;
     }
 
+    public boolean isIbanRequired(Aspsp aspsp) {
+        return bankBusiness.isIbanRequired(aspsp);
+    }
+
+    public boolean isCompatibleBank(Aspsp aspsp, final String paymentMode) {
+        return bankBusiness.isCompatibleBank(aspsp.getDetails(), paymentMode);
+    }
+
     protected Map<String, BankAffiliation> fetchMotherBanks(String motherBankPath) {
         try (InputStream input = this.getClass().getClassLoader().getResourceAsStream(motherBankPath)) {
             if (input == null) {

--- a/src/main/java/com/payline/payment/equens/service/GenericPaymentService.java
+++ b/src/main/java/com/payline/payment/equens/service/GenericPaymentService.java
@@ -10,7 +10,6 @@ import com.payline.payment.equens.bean.business.reachdirectory.GetAspspsResponse
 import com.payline.payment.equens.bean.configuration.RequestConfiguration;
 import com.payline.payment.equens.exception.InvalidDataException;
 import com.payline.payment.equens.exception.PluginException;
-import com.payline.payment.equens.service.impl.ConfigurationServiceImpl;
 import com.payline.payment.equens.utils.Constants;
 import com.payline.payment.equens.utils.PluginUtils;
 import com.payline.payment.equens.utils.http.PisHttpClient;
@@ -141,7 +140,7 @@ public class GenericPaymentService {
      * @param paylineAddress the Payline address
      * @return The corresponding Equens address.
      */
-    static Address buildAddress(Buyer.Address paylineAddress) {
+    Address buildAddress(Buyer.Address paylineAddress) {
         if (paylineAddress == null) {
             return null;
         }
@@ -196,11 +195,40 @@ public class GenericPaymentService {
         }
     }
 
-    void validateIban(GenericPaymentRequest paymentRequest, PaymentData paymentData) {
-
+    void validPaymentData(final PaymentData paymentData, final String pluginConfiguration, final GenericPaymentRequest paymentRequest) {
         // get the list of countryCode available by the merchant
         final List<String> listCountryCode = PluginUtils.createListCountry(
                 paymentRequest.getContractConfiguration().getProperty(Constants.ContractConfigurationKeys.COUNTRIES).getValue());
+        final String paymentMode = paymentRequest.getContractConfiguration().getProperty(Constants.ContractConfigurationKeys.PAYMENT_PRODUCT).getValue();
+        final String aspspId = paymentData.getAspspId();
+
+        if (PluginUtils.isEmpty(aspspId)) {
+            throw new InvalidDataException("AspspId is required");
+        }
+
+        final Aspsp aspsp = bankService.getAspsp(pluginConfiguration, aspspId);
+        if (aspsp == null) {
+            throw new InvalidDataException("Aspsp not found");
+        }
+
+        if (!listCountryCode.isEmpty() && !listCountryCode.contains(aspsp.getCountryCode())) {
+            throw new InvalidDataException("Aspsp not available for this country");
+        }
+
+        if (!bankService.isCompatibleBank(aspsp, paymentMode)) {
+            throw new InvalidDataException("Aspsp not compatible with this payment mode");
+        }
+        if (bankService.isIbanRequired(aspsp)) {
+            validateIban(paymentRequest, paymentData, aspsp, listCountryCode);
+        }
+
+    }
+
+    void validateIban(GenericPaymentRequest paymentRequest, PaymentData paymentData, Aspsp aspsp, final List<String> listCountryCode) {
+
+        if (PluginUtils.isEmpty(paymentData.getIban())) {
+            throw new InvalidDataException("Iban is required");
+        }
 
         String countryCode = "";
         // get the countryCode from the BIC or ASPSP id
@@ -209,20 +237,12 @@ public class GenericPaymentService {
                     jsonService.fromJson(paymentRequest.getPluginConfiguration(), GetAspspsResponse.class).getAspsps()
                     , paymentData.getBic());
         }
-        if (paymentData.getAspspId() != null){
-            final Aspsp aspsp = bankService.getAspsp(paymentRequest.getPluginConfiguration(), paymentData.getAspspId());
-            if (aspsp != null) {
-                countryCode = aspsp.getCountryCode();
-            }
+        else {
+            countryCode = aspsp.getCountryCode();
         }
 
         if (PluginUtils.isEmpty(countryCode)) {
             throw new InvalidDataException("Unable to determine country code for this transaction");
-        }
-
-        // if the buyer choose a bank from Spain, IBAN is required
-        if (countryCode.equalsIgnoreCase(ConfigurationServiceImpl.CountryCode.ES.name()) && PluginUtils.isEmpty(paymentData.getIban())) {
-            throw new InvalidDataException("IBAN is required for Spain");
         }
 
         // if the buyer want to use his IBAN, it should be an IBAN from a country available by the merchant
@@ -234,25 +254,18 @@ public class GenericPaymentService {
     // Build PaymentInitiationRequest (Equens) from PaymentRequest (Payline)
     protected PaymentInitiationRequest buildPaymentInitiationRequest(GenericPaymentRequest paymentRequest, Psu newPsu, PaymentData paymentData) {
 
-        // extract BIC and IBAN
-        final String bic = paymentData.getBic();
-        final String iban = paymentData.getIban();
-        String aspspId = paymentData.getAspspId();
-
         // Control on the input data (to avoid NullPointerExceptions)
         validateRequest(paymentRequest);
-        validateIban(paymentRequest, paymentData);
-        if (aspspId == null) {
-            aspspId = PluginUtils.getAspspIdFromBIC(
-                    jsonService.fromJson(paymentRequest.getPluginConfiguration(), GetAspspsResponse.class).getAspsps()
-                    , bic);
-        }
+        validPaymentData(paymentData, paymentRequest.getPluginConfiguration(), paymentRequest);
 
         // Extract delivery address
         Address deliveryAddress = null;
         if (paymentRequest.getBuyer().getAddresses() != null) {
             deliveryAddress = buildAddress(paymentRequest.getBuyer().getAddressForType(Buyer.AddressType.DELIVERY));
         }
+
+        final String iban = paymentData.getIban();
+        final String aspspId = paymentData.getAspspId();
         final String merchantName = paymentRequest.getContractConfiguration().getProperty(Constants.ContractConfigurationKeys.MERCHANT_NAME).getValue();
         final String creditorName =  PluginUtils.isEmpty(merchantName) ? null : merchantName;
         final String creditorAccountIdentification = paymentRequest.getContractConfiguration().getProperty(Constants.ContractConfigurationKeys.MERCHANT_IBAN).getValue();
@@ -275,12 +288,8 @@ public class GenericPaymentService {
                                 .withReference(paymentRequest.getOrder().getReference())
                                 .build()
                 )
-                .withCreditorAccount(
-                        creditorAccount
-                )
-                .withCreditorName(
-                       creditorName
-                )
+                .withCreditorAccount(creditorAccount)
+                .withCreditorName(creditorName)
                 .withPaymentAmount(convertAmount(paymentRequest.getAmount()))
                 .withPaymentCurrency(paymentRequest.getAmount().getCurrency().getCurrencyCode())
                 .withPurposeCode(
@@ -297,9 +306,7 @@ public class GenericPaymentService {
                                 .withMerchantCategoryCode(paymentRequest.getSubMerchant() != null ? paymentRequest.getSubMerchant().getSubMerchantMCC() : null)
                                 .withMerchantCustomerId(paymentRequest.getBuyer().getCustomerIdentifier())
                                 .withDeliveryAddress(deliveryAddress)
-                                .withChannelType(
-                                        paymentRequest.getContractConfiguration().getProperty(Constants.ContractConfigurationKeys.CHANNEL_TYPE).getValue()
-                                )
+                                .withChannelType(paymentRequest.getContractConfiguration().getProperty(Constants.ContractConfigurationKeys.CHANNEL_TYPE).getValue())
                                 .build()
                 )
                 .addPreferredScaMethod(

--- a/src/main/java/com/payline/payment/equens/service/impl/WalletServiceImpl.java
+++ b/src/main/java/com/payline/payment/equens/service/impl/WalletServiceImpl.java
@@ -52,7 +52,6 @@ public class WalletServiceImpl implements WalletService {
     public WalletCreateResponse createWallet(WalletCreateRequest walletCreateRequest) {
         try {
             // get wallet data
-
             final Map<String, String> paymentFormParameter = walletCreateRequest.getPaymentFormContext().getPaymentFormParameter();
 
             String bic = paymentFormParameter.get(BankTransferForm.BANK_KEY);

--- a/src/main/java/com/payline/payment/equens/utils/Constants.java
+++ b/src/main/java/com/payline/payment/equens/utils/Constants.java
@@ -89,6 +89,7 @@ public class Constants {
         public static final String FIELD_SUBSIDIARY_ERROR_MSG = "paymentForm.input.field.subsidiary.error.message";
 
         public static final String FIELD_SUBSIDIARY_REQUIRED_MSG = "paymentForm.input.field.subsidiary.required.message";
+        public static final String FIELD_IBAN_REQUIRED_MSG = "paymentForm.input.field.iban.required.message";
 
         /* Static utility class : no need to instantiate it (Sonar bug fix) */
         private FormKeys() {

--- a/src/main/resources/equensForm.js
+++ b/src/main/resources/equensForm.js
@@ -1,70 +1,86 @@
 const $ = Payline.jQuery;
 const aspspsList = [$BANKS_TO_REPLACE$];
-const errorSubAspsp = "$ASPSP_MSG$";
 
-function fillSubAspspId(subList) {
-    subList.forEach(function(item) {
-        $("[id$='subAspspId-options']").append($('<option>').val(item.label));
+// Selection d'un ASPSP par rapport à son identifiant.
+function getAspspById(aspspId) {
+    let aspsp =  aspspsList.filter(function (elem) {
+        return (elem.id === aspspId);
     });
+    if (aspsp.length > 0 ) {
+        return aspsp[0];
+    }
 }
 
-function updateAspspOption(bank) {
-    $("[id$='subAspspId-options']").empty();
-    $("[id$='subAspspId-container']").hide();
-    aspspsList.forEach(function(item) {
-        if (bank === item.id) {
-            $("[id$='subAspspId-container']").show();
-            fillSubAspspId(item.subList);
-        }
-    });
-}
-
-function validatePaymentMethodForm() {
-    let validation = true;
-    let $subAspspSelect = $("[id$='subAspspId']");
-    let $subAspspSelectContainer = $("[id$='subAspspId-container']");
-
-    removeSubAspspMessage();
-    let subAspspValue = $subAspspSelect.val();
-    if ($($subAspspSelectContainer).is(":visible")) {
-        let match = $("[id$='subAspspId-options'] option").filter(function() {
-            return ($(this).val() === subAspspValue);
+//Selection de la valeur actuelle d'un SubAspsp
+function getSubAspsp() {
+    let aspspValue = $("[id$='aspspId']").val();
+    let subAspspValue = $("[id$='subAspspId']").val();
+    let result;
+    let aspsp = getAspspById(aspspValue)
+    if (!Payline.u.isUndefined(aspsp) && !Payline.u.isUndefined(aspsp.subList)&& aspsp.subList.length > 0) {
+        result = aspsp.subList.filter(function (elem) {
+            return (elem.label === subAspspValue);
         });
-        if (match.length === 0 ) {
-            //afficher message d'erreur.
-            addSubAspspErrorMessage();
-            validation = false;
-        }
     }
-    return validation;
-}
-
-function addSubAspspErrorMessage() {
-    let $subAspspContainer = $("[id$='subAspspId-container']");
-    $subAspspContainer.prepend('<p id="subAspspId-message" class="pl-message pl-message-error">' + errorSubAspsp + '</p>');
-    $subAspspContainer.removeClass('pl-has-no-error');
-    $subAspspContainer.addClass('pl-has-error');
-
-}
-
-function removeSubAspspMessage() {
-    let $subAspspMessage = $("#subAspspId-message");
-    if ($subAspspMessage.length) {
-        $subAspspMessage.remove();
+    if (result.length > 0 ) {
+        return result[0];
     }
 }
+
+//Mettre à jour la liste des aspspOption.
+function updateAspspOption(bank) {
+   let $subAspspContainer = $("[id$='subAspspId-container']");
+    let aspsp = getAspspById(bank);
+    $("[id$='subAspspId-options']").empty();
+    $subAspspContainer.hide();
+
+    if (!Payline.u.isUndefined(aspsp) && !Payline.u.isUndefined(aspsp.subList) && aspsp.subList.length > 0) {
+        $subAspspContainer.show();
+        aspsp.subList.forEach(function (item) {
+            $("[id$='subAspspId-options']").append($('<option>').val(item.label));
+        });
+    }
+    displayIbanContainer(aspsp);
+}
+
+//Affichage ou non du container Iban selon la banque passé en paramètre
+function displayIbanContainer(bank) {
+    if (!Payline.u.isUndefined(bank) && bank.iban) {
+        $("[id$='iban-container']").show();
+    } else {
+        $("[id$='iban-container']").hide();
+    }
+}
+
+function PMAPIEventUpdateDynamicFields() {
+    let result = [];
+    let subAspspField = {};
+    let ibanField = {};
+    let $subAspspSelectContainer = $("[id$='subAspspId-container']");
+    let $ibanContainer = $("[id$='iban-container']");
+    subAspspField.key = "subAspspId"
+    ibanField.key="iban";
+    subAspspField.required = !!$($subAspspSelectContainer).is(":visible");
+    ibanField.required = !!$($ibanContainer).is(":visible");
+
+    result[0] = subAspspField;
+    result[1] = ibanField;
+
+    return result;
+}
+
 
 $(document).ready(function() {
     let $aspspSelect = $("[id$='aspspId']");
-    let $subAspsp = $("[id$='subAspspId']");
+    let $subAspspSelect = $("[id$='subAspspId']");
     updateAspspOption($aspspSelect.val());
+
     $aspspSelect.change(function() {
         $("[id$='subAspspId']").val('');
-        removeSubAspspMessage();
         let bank = $( this ).val();
         updateAspspOption(bank);
     });
-    $subAspsp.change(function() {
-        removeSubAspspMessage();
+    $subAspspSelect.change(function() {
+        displayIbanContainer(getSubAspsp());
     })
 });

--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -58,6 +58,8 @@ paymentForm.buttonText=
 paymentForm.description=
 
 paymentForm.input.field.iban.label =
+paymentForm.input.field.iban.required.message =
+
 paymentForm.input.field.or =
 paymentForm.input.field.banks.label =
 paymentForm.input.field.banks.placeholder =

--- a/src/main/resources/messages_en.properties
+++ b/src/main/resources/messages_en.properties
@@ -58,6 +58,8 @@ paymentForm.buttonText=
 paymentForm.description=
 
 paymentForm.input.field.iban.label =
+paymentForm.input.field.iban.required.message=
+
 paymentForm.input.field.or =
 paymentForm.input.field.banks.label =
 paymentForm.input.field.banks.placeholder =

--- a/src/main/resources/messages_fr.properties
+++ b/src/main/resources/messages_fr.properties
@@ -47,6 +47,7 @@ contract.pisp.requiredError=Veuillez renseigner la r\u00e9f\u00e9rence contrat P
 contract.pisp.badFormat=la r\u00e9f\u00e9rence contrat PISP doit contenir uniquement 12 chiffres
 
 paymentForm.input.field.iban.label = Vous connaissez votre num\u00E9ro de compte
+paymentForm.input.field.iban.required.message = Veuillez entrer un IBAN
 paymentForm.input.field.or = OU
 paymentForm.input.field.banks.label = S\u00E9lectionnez votre banque
 paymentForm.input.field.banks.placeholder = Votre banque

--- a/src/test/java/com/payline/payment/equens/MockUtils.java
+++ b/src/test/java/com/payline/payment/equens/MockUtils.java
@@ -146,7 +146,7 @@ public class MockUtils {
     /**
      * Generate a valid {@link ContractConfiguration}.
      */
-    public static ContractConfiguration aContractConfiguration(String exampleCountry) {
+    public static ContractConfiguration aContractConfiguration(String exampleCountry, final String paymentMode) {
         Map<String, ContractProperty> contractProperties = new HashMap<>();
         contractProperties.put(Constants.ContractConfigurationKeys.CHANNEL_TYPE,
                 new ContractProperty(ConfigurationServiceImpl.ChannelType.ECOMMERCE.getType()));
@@ -164,11 +164,19 @@ public class MockUtils {
                 new ContractProperty(exampleCountry));
         contractProperties.put(Constants.ContractConfigurationKeys.PISP_CONTRACT,
                 new ContractProperty("123456789012"));
-        contractProperties.put(Constants.ContractConfigurationKeys.PAYMENT_PRODUCT, new ContractProperty("Instant"));
+        contractProperties.put(Constants.ContractConfigurationKeys.PAYMENT_PRODUCT, new ContractProperty(paymentMode));
         contractProperties.put(Constants.ContractConfigurationKeys.INITIATING_PARTY_SUBID, new ContractProperty("12"));
 
         return new ContractConfiguration("INST EquensWorldline", contractProperties);
     }
+
+    /**
+     * Generate a valid {@link ContractConfiguration}.
+     */
+    public static ContractConfiguration aContractConfiguration(String exampleCountry) {
+        return aContractConfiguration(exampleCountry, "Instant");
+    }
+
 
     /**
      * Generate a valid {@link ContractParametersCheckRequest}.
@@ -449,10 +457,11 @@ public class MockUtils {
     public static String aPluginConfiguration() {
         return "{\"Application\":\"PIS\",\"ASPSP\":[" +
                     "{\"AspspId\":\"1409\",\"Name\":[\"La Banque Postale\"],\"CountryCode\":\"FR\",\"BIC\":\"PSSTFRPP\"}," +
-                    "{\"AspspId\":\"1410\",\"Name\":[\"La Banque\"],\"CountryCode\":\"ES\",\"BIC\":\"PSSTFRPT\"}," +
-                    "{\"AspspId\":\"1601\",\"Name\":[\"BBVA\"],\"CountryCode\":\"ES\",\"BIC\":\"BBVAESMM\"}" +
-                "],\"MessageCreateDateTime\":\"2019-11-15T16:52:37.092+0100\",\"MessageId\":\"6f31954f-7ad6-4a63-950c-a2a363488e\"}";
+                    "{\"AspspId\":\"1601\",\"Name\":[\"BBVA\"],\"CountryCode\":\"ES\",\"BIC\":\"BBVAESMM\"}," +
+                    "{\"AspspId\":\"1410\", \"BIC\":\"PSSTFRPT\", \"CountryCode\":\"FR\", \"Name\":[ \"La Banque\"], \"Details\":[ { \"Api\":\"POST /payments\", \"Fieldname\":\"DebtorAccount\", \"Type\":\"MANDATORY\", \"ProtocolVersion\":\"BG_V_1_3_0\" }, { \"Api\":\"POST /payments\", \"Fieldname\":\"PaymentProduct\", \"Type\":\"SUPPORTED\", \"Value\":\"Instant\", \"ProtocolVersion\":\"BG_V_1_3_0\" } ] }"+
+                    "],\"MessageCreateDateTime\":\"2019-11-15T16:52:37.092+0100\",\"MessageId\":\"6f31954f-7ad6-4a63-950c-a2a363488e\"}";
     }
+
 
     /**
      * @return A fake private key, for test purpose.
@@ -639,7 +648,8 @@ public class MockUtils {
     public static PaymentData.PaymentDataBuilder aPaymentDataBuilder() {
         return new PaymentData.PaymentDataBuilder()
                 .withBic("PSSTFRPT")
-                .withIban(ibanFR);
+                .withIban(ibanFR)
+                .withAspspId("1410");
     }
 
     public static String getExampleCountry() {

--- a/src/test/java/com/payline/payment/equens/service/GenericPaymentServiceTest.java
+++ b/src/test/java/com/payline/payment/equens/service/GenericPaymentServiceTest.java
@@ -10,6 +10,7 @@ import com.payline.payment.equens.bean.business.psu.PsuCreateRequest;
 import com.payline.payment.equens.bean.configuration.RequestConfiguration;
 import com.payline.payment.equens.exception.InvalidDataException;
 import com.payline.payment.equens.exception.PluginException;
+import com.payline.payment.equens.service.impl.ConfigurationServiceImpl;
 import com.payline.payment.equens.utils.Constants;
 import com.payline.payment.equens.utils.TestUtils;
 import com.payline.payment.equens.utils.http.PisHttpClient;
@@ -26,6 +27,7 @@ import com.payline.pmapi.bean.payment.response.impl.PaymentResponseFailure;
 import com.payline.pmapi.bean.payment.response.impl.PaymentResponseRedirect;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
@@ -41,353 +43,408 @@ import static org.mockito.Mockito.doThrow;
 
 class GenericPaymentServiceTest {
 
-    @InjectMocks
-    private GenericPaymentService service;
 
     @Mock
     private PisHttpClient pisHttpClient;
     @Mock
     private PsuHttpClient psuHttpclient;
 
+    @InjectMocks
+    private GenericPaymentService underTest;
+
+
     @BeforeEach
     void setUp() {
-        service = GenericPaymentService.getInstance();
+        underTest = GenericPaymentService.getInstance();
         MockitoAnnotations.initMocks(this);
     }
 
-    @Test
-    void paymentRequest() {
-        doReturn(MockUtils.aPsu()).when(psuHttpclient).createPsu(any(), any());
-        doReturn(MockUtils.aPaymentInitiationResponse()).when(pisHttpClient).initPayment(any(), any());
+    @Nested
+    public class testPaymentRequest {
 
-        PaymentData paymentData = MockUtils.aPaymentdata();
-        // when: calling paymentRequest() method
-        PaymentRequest paymentRequest = MockUtils.aPaylinePaymentRequest();
-        GenericPaymentRequest genericPaymentRequest = new GenericPaymentRequest(paymentRequest);
-        PaymentResponse paymentResponse = service.paymentRequest(genericPaymentRequest, paymentData);
+        @Test
+        void nominalCase() {
+            doReturn(MockUtils.aPsu()).when(psuHttpclient).createPsu(any(), any());
+            doReturn(MockUtils.aPaymentInitiationResponse()).when(pisHttpClient).initPayment(any(), any());
 
-        // then: the payment response is a success
-        assertEquals(PaymentResponseRedirect.class, paymentResponse.getClass());
-        TestUtils.checkPaymentResponse((PaymentResponseRedirect) paymentResponse);
+            final PaymentData paymentData = MockUtils.aPaymentdata();
+            // when: calling paymentRequest() method
+            final PaymentRequest paymentRequest = MockUtils.aPaylinePaymentRequest();
+            final GenericPaymentRequest genericPaymentRequest = new GenericPaymentRequest(paymentRequest);
+            final PaymentResponse paymentResponse = underTest.paymentRequest(genericPaymentRequest, paymentData);
+
+            // then: the payment response is a success
+            assertEquals(PaymentResponseRedirect.class, paymentResponse.getClass());
+            TestUtils.checkPaymentResponse((PaymentResponseRedirect) paymentResponse);
+        }
+
+        @Test
+        void paymentRequest_EmptyMerchantName() {
+            doReturn(MockUtils.aPsu()).when(psuHttpclient).createPsu(any(), any());
+            final JsonService jsonService = JsonService.getInstance();
+
+            final PaymentData paymentData = MockUtils.aPaymentdata();
+            // when: calling paymentRequest() method
+            final PaymentRequest paymentRequest = MockUtils.aPaylinePaymentRequest();
+
+            paymentRequest.getContractConfiguration().getContractProperties().remove(Constants.ContractConfigurationKeys.MERCHANT_NAME);
+            paymentRequest.getContractConfiguration().getContractProperties().put(Constants.ContractConfigurationKeys.MERCHANT_NAME, new ContractProperty(""));
+
+            GenericPaymentRequest genericPaymentRequest = new GenericPaymentRequest(paymentRequest);
+
+            // Build request configuration
+            final RequestConfiguration requestConfiguration = new RequestConfiguration(
+                    paymentRequest.getContractConfiguration()
+                    , paymentRequest.getEnvironment()
+                    , paymentRequest.getPartnerConfiguration()
+            );
+
+            // Create a new PSU
+            final Psu newPsu = psuHttpclient.createPsu(new PsuCreateRequest.PsuCreateRequestBuilder().build(), requestConfiguration);
+
+            // Build PaymentInitiationRequest (Equens) from PaymentRequest (Payline)
+            final PaymentInitiationRequest request = underTest.buildPaymentInitiationRequest(genericPaymentRequest, newPsu, paymentData);
+
+            final String chaine = jsonService.toJson(request);
+
+            assertFalse(chaine.contains("CreditorName"));
+
+        }
+
+        @Test
+        void paymentRequest_EmptyMerchantIban() {
+            doReturn(MockUtils.aPsu()).when(psuHttpclient).createPsu(any(), any());
+            final JsonService jsonService = JsonService.getInstance();
+
+            final PaymentData paymentData = MockUtils.aPaymentdata();
+            // when: calling paymentRequest() method
+            final PaymentRequest paymentRequest = MockUtils.aPaylinePaymentRequest();
+
+            paymentRequest.getContractConfiguration().getContractProperties().remove(Constants.ContractConfigurationKeys.MERCHANT_IBAN);
+            paymentRequest.getContractConfiguration().getContractProperties().put(Constants.ContractConfigurationKeys.MERCHANT_IBAN, new ContractProperty(""));
+
+            final GenericPaymentRequest genericPaymentRequest = new GenericPaymentRequest(paymentRequest);
+
+            // Build request configuration
+            final RequestConfiguration requestConfiguration = new RequestConfiguration(
+                    paymentRequest.getContractConfiguration()
+                    , paymentRequest.getEnvironment()
+                    , paymentRequest.getPartnerConfiguration()
+            );
+
+            // Create a new PSU
+            final Psu newPsu = psuHttpclient.createPsu(new PsuCreateRequest.PsuCreateRequestBuilder().build(), requestConfiguration);
+
+            // Build PaymentInitiationRequest (Equens) from PaymentRequest (Payline)
+            final PaymentInitiationRequest request = underTest.buildPaymentInitiationRequest(genericPaymentRequest, newPsu, paymentData);
+
+            final String chaine = jsonService.toJson(request);
+            assertFalse(chaine.contains("CreditorAccount"));
+
+        }
+
+        @Test
+        void paymentRequest_check_MerchantName_MerchantIban() {
+            doReturn(MockUtils.aPsu()).when(psuHttpclient).createPsu(any(), any());
+            final JsonService jsonService = JsonService.getInstance();
+
+            final PaymentData paymentData = MockUtils.aPaymentdata();
+            // when: calling paymentRequest() method
+            final PaymentRequest paymentRequest = MockUtils.aPaylinePaymentRequest();
+
+            final GenericPaymentRequest genericPaymentRequest = new GenericPaymentRequest(paymentRequest);
+
+            // Build request configuration
+            final RequestConfiguration requestConfiguration = new RequestConfiguration(
+                    paymentRequest.getContractConfiguration()
+                    , paymentRequest.getEnvironment()
+                    , paymentRequest.getPartnerConfiguration()
+            );
+
+            // Create a new PSU
+            final Psu newPsu = psuHttpclient.createPsu(new PsuCreateRequest.PsuCreateRequestBuilder().build(), requestConfiguration);
+
+            // Build PaymentInitiationRequest (Equens) from PaymentRequest (Payline)
+            final PaymentInitiationRequest request = underTest.buildPaymentInitiationRequest(genericPaymentRequest, newPsu, paymentData);
+
+            final String chaine = jsonService.toJson(request);
+
+            assertTrue(chaine.contains("CreditorAccount"));
+            assertTrue(chaine.contains("CreditorName"));
+        }
+
+        @Test
+        void paymentRequest_pisInitError() {
+            // given: the pisHttpClient init throws an exception (invalid certificate data in PartnerConfiguration, for example)
+            doThrow(new PluginException("A problem occurred initializing SSL context", FailureCause.INVALID_DATA))
+                    .when(pisHttpClient)
+                    .init(any(PartnerConfiguration.class));
+
+            final PaymentData paymentData = MockUtils.aPaymentdata();
+            // when: calling paymentRequest() method
+
+            final PaymentRequest paymentRequest = MockUtils.aPaylinePaymentRequest();
+            final GenericPaymentRequest genericPaymentRequest = new GenericPaymentRequest(paymentRequest);
+            final PaymentResponse paymentResponse = underTest.paymentRequest(genericPaymentRequest, paymentData);
+
+            // then: the exception is properly catch and the payment response is a failure
+            assertEquals(PaymentResponseFailure.class, paymentResponse.getClass());
+            TestUtils.checkPaymentResponse((PaymentResponseFailure) paymentResponse);
+        }
+
+        @Test
+        void paymentRequest_psuCreateError() {
+            // given: the creation of the PSU fails
+            doThrow(new PluginException("partner error: 500 Internal Server Error"))
+                    .when(psuHttpclient)
+                    .createPsu(any(PsuCreateRequest.class), any(RequestConfiguration.class));
+
+            final PaymentData paymentData = MockUtils.aPaymentdata();
+            // when: calling paymentRequest() method
+            final PaymentRequest paymentRequest = MockUtils.aPaylinePaymentRequest();
+            final GenericPaymentRequest genericPaymentRequest = new GenericPaymentRequest(paymentRequest);
+            final PaymentResponse paymentResponse = underTest.paymentRequest(genericPaymentRequest, paymentData);
+
+            // then: the exception is properly catch and the payment response is a failure
+            assertEquals(PaymentResponseFailure.class, paymentResponse.getClass());
+            TestUtils.checkPaymentResponse((PaymentResponseFailure) paymentResponse);
+        }
+
+        @Test
+        void paymentRequest_paymentInitError() {
+            final PaymentData paymentData = MockUtils.aPaymentdata();
+            // given: the payment initiation fails
+            doReturn(MockUtils.aPsu())
+                    .when(psuHttpclient)
+                    .createPsu(any(PsuCreateRequest.class), any(RequestConfiguration.class));
+            doThrow(new PluginException("partner error: 500 Internal Server Error"))
+                    .when(pisHttpClient)
+                    .initPayment(any(PaymentInitiationRequest.class), any(RequestConfiguration.class));
+
+            // when: calling paymentRequest() method
+            final PaymentRequest paymentRequest = MockUtils.aPaylinePaymentRequest();
+            final GenericPaymentRequest genericPaymentRequest = new GenericPaymentRequest(paymentRequest);
+            final PaymentResponse paymentResponse = underTest.paymentRequest(genericPaymentRequest, paymentData);
+
+            // then: the exception is properly catch and the payment response is a failure
+            assertEquals(PaymentResponseFailure.class, paymentResponse.getClass());
+            TestUtils.checkPaymentResponse((PaymentResponseFailure) paymentResponse);
+        }
+
+        @Test
+        void paymentRequest_missingContractProperty() {
+            final PaymentData paymentData = MockUtils.aPaymentdata();
+            // given: a property is missing from ContractConfiguration
+            final ContractConfiguration contractConfiguration = MockUtils.aContractConfiguration(MockUtils.getExampleCountry());
+            contractConfiguration.getContractProperties().remove(Constants.ContractConfigurationKeys.MERCHANT_IBAN);
+            final PaymentRequest paymentRequest = MockUtils.aPaylinePaymentRequestBuilder()
+                    .withContractConfiguration(contractConfiguration)
+                    .build();
+            doReturn(MockUtils.aPsu())
+                    .when(psuHttpclient)
+                    .createPsu(any(PsuCreateRequest.class), any(RequestConfiguration.class));
+
+            // when: calling paymentRequest() method
+            final GenericPaymentRequest genericPaymentRequest = new GenericPaymentRequest(paymentRequest);
+            final PaymentResponse paymentResponse = underTest.paymentRequest(genericPaymentRequest, paymentData);
+
+            // then: the exception is properly catch and the payment response is a failure
+            assertEquals(PaymentResponseFailure.class, paymentResponse.getClass());
+            TestUtils.checkPaymentResponse((PaymentResponseFailure) paymentResponse);
+        }
+
     }
 
-    @Test
-    void paymentRequest_EmptyMerchantName() {
-        doReturn(MockUtils.aPsu()).when(psuHttpclient).createPsu(any(), any());
-        JsonService jsonService = JsonService.getInstance();
+    @Nested
+    public class buildPaymentInitiationRequest {
+        @Test
+        void buildPaymentInitiationRequest() {
+            final Psu psu = MockUtils.aPsu();
+            final PaymentData paymentData = MockUtils.aPaymentdata();
+            final GenericPaymentRequest genericPaymentRequest = new GenericPaymentRequest(MockUtils.aPaylinePaymentRequest());
+            final String ibanFR = MockUtils.getIbanFR();
+            final PaymentInitiationRequest expected = MockUtils.aPaymentInitiationRequest(ibanFR);
 
-        PaymentData paymentData = MockUtils.aPaymentdata();
-        // when: calling paymentRequest() method
-        PaymentRequest paymentRequest = MockUtils.aPaylinePaymentRequest();
+            final PaymentInitiationRequest result = underTest.buildPaymentInitiationRequest(genericPaymentRequest, psu, paymentData);
+            assertEquals(result.getAspspId(), expected.getAspspId());
+            assertEquals(result.getChargeBearer(), expected.getChargeBearer());
+            assertEquals(result.getCreditorAccount().getIdentification(), expected.getCreditorAccount().getIdentification());
+            assertEquals(result.getDebtorAccount().getIdentification(), expected.getDebtorAccount().getIdentification());
+            assertEquals(result.getCreditorName(), expected.getCreditorName());
+            assertEquals(result.getEndToEndId(), expected.getEndToEndId());
+            assertEquals(result.getInitiatingPartyReferenceId(), expected.getInitiatingPartyReferenceId());
+            assertEquals(result.getInitiatingPartyReturnUrl(), expected.getInitiatingPartyReturnUrl());
+            assertEquals(result.getPaymentAmount(), expected.getPaymentAmount());
+            assertEquals(result.getPaymentCurrency(), expected.getPaymentCurrency());
+            assertEquals(result.getPaymentProduct(), expected.getPaymentProduct());
+            assertEquals(result.getPreferredScaMethod(), expected.getPreferredScaMethod());
+            assertEquals(result.getPsuId(), expected.getPsuId());
+            assertEquals(result.getPsuSessionInformation().getHeaderUserAgent(), expected.getPsuSessionInformation().getHeaderUserAgent());
+            assertEquals(result.getPsuSessionInformation().getIpAddress(), expected.getPsuSessionInformation().getIpAddress());
+            assertEquals(result.getPurposeCode(), expected.getPurposeCode());
+            assertEquals(result.getRemittanceInformation(), expected.getRemittanceInformation());
+            assertEquals(result.getRemittanceInformationStructured().getReference(), expected.getRemittanceInformationStructured().getReference());
+            assertEquals(result.getRiskInformation().getChannelType(), expected.getRiskInformation().getChannelType());
+            assertEquals(result.getRiskInformation().getMerchantCategoryCode(), expected.getRiskInformation().getMerchantCategoryCode());
+            assertEquals(result.getRiskInformation().getMerchantCustomerId(), expected.getRiskInformation().getMerchantCustomerId());
+            assertEquals(result.getDebtorName(), expected.getDebtorName());
+            assertEquals(result.getInitiatingPartySubId(), expected.getInitiatingPartySubId());
 
-        paymentRequest.getContractConfiguration().getContractProperties().remove(Constants.ContractConfigurationKeys.MERCHANT_NAME);
-        paymentRequest.getContractConfiguration().getContractProperties().put(Constants.ContractConfigurationKeys.MERCHANT_NAME, new ContractProperty(""));
+        }
 
-        GenericPaymentRequest genericPaymentRequest = new GenericPaymentRequest(paymentRequest);
+        @Test
+        void buildPaymentInitiationRequest_AspspNull() {
+            final Psu psu = MockUtils.aPsu();
+            final PaymentData paymentData = MockUtils.aPaymentDataBuilder().withAspspId(null).build();
+            final ContractConfiguration contractConfiguration = MockUtils.aContractConfiguration(MockUtils.getExampleCountry(), ConfigurationServiceImpl.PaymentProduct.NORMAL.getPaymentProductCode());
 
-        // Build request configuration
-        RequestConfiguration requestConfiguration = new RequestConfiguration(
-                paymentRequest.getContractConfiguration()
-                , paymentRequest.getEnvironment()
-                , paymentRequest.getPartnerConfiguration()
-        );
+            // create a genericPaymentRequest with an empty IBAN and a BIC from Spain
+            final GenericPaymentRequest genericPaymentRequest = new GenericPaymentRequest(
+                    MockUtils.aPaylinePaymentRequestBuilder()
+                            .withPaymentFormContext(MockUtils.aPaymentFormContext(paymentData.getIban()))
+                            .build());
 
-        // Create a new PSU
-        Psu newPsu = psuHttpclient.createPsu(new PsuCreateRequest.PsuCreateRequestBuilder().build(), requestConfiguration);
 
-        // Build PaymentInitiationRequest (Equens) from PaymentRequest (Payline)
-        PaymentInitiationRequest request = service.buildPaymentInitiationRequest(genericPaymentRequest, newPsu, paymentData);
+            final InvalidDataException thrown = Assertions.assertThrows(InvalidDataException.class,
+                    () -> underTest.buildPaymentInitiationRequest(genericPaymentRequest, psu, paymentData));
 
-        String chaine = jsonService.toJson(request);
+            assertEquals("AspspId is required", thrown.getMessage());
+        }
 
-        assertFalse(chaine.contains("CreditorName"));
+        @Test
+        void buildPaymentInitiationRequest_AspspNotFound() {
+            final Psu psu = MockUtils.aPsu();
+            final PaymentData paymentData = MockUtils.aPaymentDataBuilder().withAspspId("9999").build();
+            final ContractConfiguration contractConfiguration = MockUtils.aContractConfiguration(MockUtils.getExampleCountry(), ConfigurationServiceImpl.PaymentProduct.NORMAL.getPaymentProductCode());
+
+            // create a genericPaymentRequest with an empty IBAN and a BIC from Spain
+            final GenericPaymentRequest genericPaymentRequest = new GenericPaymentRequest(
+                    MockUtils.aPaylinePaymentRequestBuilder()
+                            .withPaymentFormContext(MockUtils.aPaymentFormContext(paymentData.getIban()))
+                            .build());
+
+
+            final InvalidDataException thrown = Assertions.assertThrows(InvalidDataException.class,
+                    () -> underTest.buildPaymentInitiationRequest(genericPaymentRequest, psu, paymentData));
+
+            assertEquals("Aspsp not found", thrown.getMessage());
+        }
+
+        @Test
+        void buildPaymentInitiationRequest_WrongPaymentMode() {
+            final Psu psu = MockUtils.aPsu();
+            final PaymentData paymentData = MockUtils.aPaymentDataBuilder().build();
+            final ContractConfiguration contractConfiguration = MockUtils.aContractConfiguration(MockUtils.getExampleCountry(), ConfigurationServiceImpl.PaymentProduct.NORMAL.getPaymentProductCode());
+
+            // create a genericPaymentRequest with an empty IBAN and a BIC from Spain
+            final GenericPaymentRequest genericPaymentRequest = new GenericPaymentRequest(
+                    MockUtils.aPaylinePaymentRequestBuilder().withContractConfiguration(contractConfiguration)
+                            .withPaymentFormContext(MockUtils.aPaymentFormContext(paymentData.getIban()))
+                            .build());
+
+
+            final InvalidDataException thrown = Assertions.assertThrows(InvalidDataException.class,
+                    () -> underTest.buildPaymentInitiationRequest(genericPaymentRequest, psu, paymentData));
+
+            assertEquals("Aspsp not compatible with this payment mode", thrown.getMessage());
+        }
+
+        @Test
+        void buildPaymentInitiationRequest_WrongIBAN() {
+            final Psu psu = MockUtils.aPsu();
+            final PaymentData paymentData = MockUtils.aPaymentDataBuilder()
+                    .withIban("IT123456789")
+                    .build();
+            // create a GenericPaymentRequest with an IBAN from a country not accepted, and the merchant lets all banks open
+            final GenericPaymentRequest genericPaymentRequest = new GenericPaymentRequest(
+                    MockUtils.aPaylinePaymentRequestBuilder()
+                            .withPaymentFormContext(MockUtils.aPaymentFormContext("IT123456789"))
+                            .withContractConfiguration(MockUtils.aContractConfiguration("TOUS"))
+                            .build());
+
+            Assertions.assertThrows(InvalidDataException.class,
+                    () -> underTest.buildPaymentInitiationRequest(genericPaymentRequest, psu, paymentData),
+                    "IBAN should be from a country available by the merchant "
+            );
+        }
+
+        @Test
+        void buildPaymentInitiationRequest_WrongCountryIBAN() {
+            final Psu psu = MockUtils.aPsu();
+            final PaymentData paymentData = MockUtils.aPaymentDataBuilder()
+                    .withIban(MockUtils.getIbanES())
+                    .build();
+            // create a GenericPaymentRequest with and IBAn from Spain, and the merchant only want it from France
+            final GenericPaymentRequest genericPaymentRequest = new GenericPaymentRequest(
+                    MockUtils.aPaylinePaymentRequestBuilder().withPaymentFormContext(MockUtils.aPaymentFormContext(MockUtils.getIbanES()))
+                            .build());
+
+            Assertions.assertThrows(InvalidDataException.class,
+                    () -> underTest.buildPaymentInitiationRequest(genericPaymentRequest, psu, paymentData),
+                    "IBAN should be from a country available by the merchant "
+            );
+        }
+    }
+
+    @Nested
+    public class testBuildAddress {
+        @Test
+        void buildAddress_nominal() {
+            // given: a Payline address
+            final Buyer.Address input = MockUtils.aPaylineAddress();
+
+            // when: feeding it to the method buildAddress()
+            final Address output = underTest.buildAddress(input);
+
+            // then: output attributes are not null and the address lines are less than 70 chars long
+            assertNotNull(output);
+            assertNotNull(output.getCountry());
+            assertNotNull(output.getPostCode());
+            assertFalse(output.getAddressLines().isEmpty());
+            output.getAddressLines().forEach(line -> assertTrue(line.length() <= Address.ADDRESS_LINE_MAX_LENGTH));
+        }
+
+        @Test
+        void buildAddress_spaceManagement() {
+            // given: an address line in which the index 69 is in the middle of a word
+            final Buyer.Address input = Buyer.Address.AddressBuilder.anAddress()
+                    .withStreet1("This is an address, but we need to be careful where to split it : notInTheMiddleOfThis")
+                    .build();
+
+            // when: feeding it to the method buildAddress()
+            final Address output = underTest.buildAddress(input);
+
+            assertEquals("This is an address, but we need to be careful where to split it :", output.getAddressLines().get(0));
+            assertEquals("notInTheMiddleOfThis", output.getAddressLines().get(1));
+        }
+
+        @Test
+        void buildAddress_veryLongChunk() {
+            // given: an address line with a very long part
+            final Buyer.Address input = Buyer.Address.AddressBuilder.anAddress()
+                    .withStreet1("ThisIsAnAddressWithoutAnySpaceAndWeNeedToSplitItSomewaySoWeTruncateBrutallyInTheMiddle")
+                    .build();
+
+            // when: feeding it to the method buildAddress()
+            final Address output = underTest.buildAddress(input);
+
+            assertEquals("ThisIsAnAddressWithoutAnySpaceAndWeNeedToSplitItSomewaySoWeTruncateBru", output.getAddressLines().get(0));
+            assertEquals("tallyInTheMiddle", output.getAddressLines().get(1));
+        }
 
     }
 
-    @Test
-    void paymentRequest_EmptyMerchantIban() {
-        doReturn(MockUtils.aPsu()).when(psuHttpclient).createPsu(any(), any());
-        JsonService jsonService = JsonService.getInstance();
 
-        PaymentData paymentData = MockUtils.aPaymentdata();
-        // when: calling paymentRequest() method
-        PaymentRequest paymentRequest = MockUtils.aPaylinePaymentRequest();
-
-        paymentRequest.getContractConfiguration().getContractProperties().remove(Constants.ContractConfigurationKeys.MERCHANT_IBAN);
-        paymentRequest.getContractConfiguration().getContractProperties().put(Constants.ContractConfigurationKeys.MERCHANT_IBAN, new ContractProperty(""));
-
-        GenericPaymentRequest genericPaymentRequest = new GenericPaymentRequest(paymentRequest);
-
-        // Build request configuration
-        RequestConfiguration requestConfiguration = new RequestConfiguration(
-                paymentRequest.getContractConfiguration()
-                , paymentRequest.getEnvironment()
-                , paymentRequest.getPartnerConfiguration()
-        );
-
-        // Create a new PSU
-        Psu newPsu = psuHttpclient.createPsu(new PsuCreateRequest.PsuCreateRequestBuilder().build(), requestConfiguration);
-
-        // Build PaymentInitiationRequest (Equens) from PaymentRequest (Payline)
-        PaymentInitiationRequest request = service.buildPaymentInitiationRequest(genericPaymentRequest, newPsu, paymentData);
-
-        String chaine = jsonService.toJson(request);
-        assertFalse(chaine.contains("CreditorAccount"));
-
-    }
-
-    @Test
-    void paymentRequest_check_MerchantName_MerchantIban() {
-        doReturn(MockUtils.aPsu()).when(psuHttpclient).createPsu(any(), any());
-        JsonService jsonService = JsonService.getInstance();
-
-        PaymentData paymentData = MockUtils.aPaymentdata();
-        // when: calling paymentRequest() method
-        PaymentRequest paymentRequest = MockUtils.aPaylinePaymentRequest();
-
-        GenericPaymentRequest genericPaymentRequest = new GenericPaymentRequest(paymentRequest);
-
-        // Build request configuration
-        RequestConfiguration requestConfiguration = new RequestConfiguration(
-                paymentRequest.getContractConfiguration()
-                , paymentRequest.getEnvironment()
-                , paymentRequest.getPartnerConfiguration()
-        );
-
-        // Create a new PSU
-        Psu newPsu = psuHttpclient.createPsu(new PsuCreateRequest.PsuCreateRequestBuilder().build(), requestConfiguration);
-
-        // Build PaymentInitiationRequest (Equens) from PaymentRequest (Payline)
-        PaymentInitiationRequest request = service.buildPaymentInitiationRequest(genericPaymentRequest, newPsu, paymentData);
-
-        String chaine = jsonService.toJson(request);
-
-        assertTrue(chaine.contains("CreditorAccount"));
-        assertTrue(chaine.contains("CreditorName"));
-    }
-
-    @Test
-    void paymentRequest_pisInitError() {
-        // given: the pisHttpClient init throws an exception (invalid certificate data in PartnerConfiguration, for example)
-        doThrow(new PluginException("A problem occurred initializing SSL context", FailureCause.INVALID_DATA))
-                .when(pisHttpClient)
-                .init(any(PartnerConfiguration.class));
-
-        PaymentData paymentData = MockUtils.aPaymentdata();
-        // when: calling paymentRequest() method
-
-        PaymentRequest paymentRequest = MockUtils.aPaylinePaymentRequest();
-        GenericPaymentRequest genericPaymentRequest = new GenericPaymentRequest(paymentRequest);
-        PaymentResponse paymentResponse = service.paymentRequest(genericPaymentRequest, paymentData);
-
-        // then: the exception is properly catch and the payment response is a failure
-        assertEquals(PaymentResponseFailure.class, paymentResponse.getClass());
-        TestUtils.checkPaymentResponse((PaymentResponseFailure) paymentResponse);
-    }
-
-    @Test
-    void paymentRequest_psuCreateError() {
-        // given: the creation of the PSU fails
-        doThrow(new PluginException("partner error: 500 Internal Server Error"))
-                .when(psuHttpclient)
-                .createPsu(any(PsuCreateRequest.class), any(RequestConfiguration.class));
-
-        PaymentData paymentData = MockUtils.aPaymentdata();
-        // when: calling paymentRequest() method
-        PaymentRequest paymentRequest = MockUtils.aPaylinePaymentRequest();
-        GenericPaymentRequest genericPaymentRequest = new GenericPaymentRequest(paymentRequest);
-        PaymentResponse paymentResponse = service.paymentRequest(genericPaymentRequest, paymentData);
-
-        // then: the exception is properly catch and the payment response is a failure
-        assertEquals(PaymentResponseFailure.class, paymentResponse.getClass());
-        TestUtils.checkPaymentResponse((PaymentResponseFailure) paymentResponse);
-    }
-
-    @Test
-    void paymentRequest_paymentInitError() {
-        PaymentData paymentData = MockUtils.aPaymentdata();
-        // given: the payment initiation fails
-        doReturn(MockUtils.aPsu())
-                .when(psuHttpclient)
-                .createPsu(any(PsuCreateRequest.class), any(RequestConfiguration.class));
-        doThrow(new PluginException("partner error: 500 Internal Server Error"))
-                .when(pisHttpClient)
-                .initPayment(any(PaymentInitiationRequest.class), any(RequestConfiguration.class));
-
-        // when: calling paymentRequest() method
-        PaymentRequest paymentRequest = MockUtils.aPaylinePaymentRequest();
-        GenericPaymentRequest genericPaymentRequest = new GenericPaymentRequest(paymentRequest);
-        PaymentResponse paymentResponse = service.paymentRequest(genericPaymentRequest, paymentData);
-
-        // then: the exception is properly catch and the payment response is a failure
-        assertEquals(PaymentResponseFailure.class, paymentResponse.getClass());
-        TestUtils.checkPaymentResponse((PaymentResponseFailure) paymentResponse);
-    }
-
-    @Test
-    void paymentRequest_missingContractProperty() {
-        PaymentData paymentData = MockUtils.aPaymentdata();
-        // given: a property is missing from ContractConfiguration
-        ContractConfiguration contractConfiguration = MockUtils.aContractConfiguration(MockUtils.getExampleCountry());
-        contractConfiguration.getContractProperties().remove(Constants.ContractConfigurationKeys.MERCHANT_IBAN);
-        PaymentRequest paymentRequest = MockUtils.aPaylinePaymentRequestBuilder()
-                .withContractConfiguration(contractConfiguration)
-                .build();
-        doReturn(MockUtils.aPsu())
-                .when(psuHttpclient)
-                .createPsu(any(PsuCreateRequest.class), any(RequestConfiguration.class));
-
-        // when: calling paymentRequest() method
-        GenericPaymentRequest genericPaymentRequest = new GenericPaymentRequest(paymentRequest);
-        PaymentResponse paymentResponse = service.paymentRequest(genericPaymentRequest, paymentData);
-
-        // then: the exception is properly catch and the payment response is a failure
-        assertEquals(PaymentResponseFailure.class, paymentResponse.getClass());
-        TestUtils.checkPaymentResponse((PaymentResponseFailure) paymentResponse);
-    }
-
-
-    @Test
-    void buildAddress_nominal() {
-        // given: a Payline address
-        Buyer.Address input = MockUtils.aPaylineAddress();
-
-        // when: feeding it to the method buildAddress()
-        Address output = service.buildAddress(input);
-
-        // then: output attributes are not null and the address lines are less than 70 chars long
-        assertNotNull(output);
-        assertNotNull(output.getCountry());
-        assertNotNull(output.getPostCode());
-        assertFalse(output.getAddressLines().isEmpty());
-        output.getAddressLines().forEach(line -> assertTrue(line.length() <= Address.ADDRESS_LINE_MAX_LENGTH));
-    }
-
-    @Test
-    void buildAddress_spaceManagement() {
-        // given: an address line in which the index 69 is in the middle of a word
-        Buyer.Address input = Buyer.Address.AddressBuilder.anAddress()
-                .withStreet1("This is an address, but we need to be careful where to split it : notInTheMiddleOfThis")
-                .build();
-
-        // when: feeding it to the method buildAddress()
-        Address output = service.buildAddress(input);
-
-        assertEquals("This is an address, but we need to be careful where to split it :", output.getAddressLines().get(0));
-        assertEquals("notInTheMiddleOfThis", output.getAddressLines().get(1));
-    }
-
-    @Test
-    void buildAddress_veryLongChunk() {
-        // given: an address line with a very long part
-        Buyer.Address input = Buyer.Address.AddressBuilder.anAddress()
-                .withStreet1("ThisIsAnAddressWithoutAnySpaceAndWeNeedToSplitItSomewaySoWeTruncateBrutallyInTheMiddle")
-                .build();
-
-        // when: feeding it to the method buildAddress()
-        Address output = service.buildAddress(input);
-
-        assertEquals("ThisIsAnAddressWithoutAnySpaceAndWeNeedToSplitItSomewaySoWeTruncateBru", output.getAddressLines().get(0));
-        assertEquals("tallyInTheMiddle", output.getAddressLines().get(1));
-    }
 
     @Test
     void convertAmount() {
-        assertNull(service.convertAmount(null));
+        assertNull(underTest.convertAmount(null));
         // Euro
-        assertEquals("0.01", service.convertAmount(new Amount(BigInteger.ONE, Currency.getInstance("EUR"))));
-        assertEquals("1.00", service.convertAmount(new Amount(BigInteger.valueOf(100), Currency.getInstance("EUR"))));
+        assertEquals("0.01", underTest.convertAmount(new Amount(BigInteger.ONE, Currency.getInstance("EUR"))));
+        assertEquals("1.00", underTest.convertAmount(new Amount(BigInteger.valueOf(100), Currency.getInstance("EUR"))));
         // Yen: no decimal
-        assertEquals("100", service.convertAmount(new Amount(BigInteger.valueOf(100), Currency.getInstance("JPY"))));
+        assertEquals("100", underTest.convertAmount(new Amount(BigInteger.valueOf(100), Currency.getInstance("JPY"))));
         // Bahrain Dinar: 3 decimals
-        assertEquals("0.100", service.convertAmount(new Amount(BigInteger.valueOf(100), Currency.getInstance("BHD"))));
-    }
-
-    @Test
-    void buildPaymentInitiationRequest() {
-        final Psu psu = MockUtils.aPsu();
-        final PaymentData paymentData = MockUtils.aPaymentdata();
-        final GenericPaymentRequest genericPaymentRequest = new GenericPaymentRequest(MockUtils.aPaylinePaymentRequest());
-        final String ibanFR = MockUtils.getIbanFR();
-        PaymentInitiationRequest exepcted = MockUtils.aPaymentInitiationRequest(ibanFR);
-
-        PaymentInitiationRequest result = service.buildPaymentInitiationRequest(genericPaymentRequest, psu, paymentData);
-        assertEquals(result.getAspspId(), exepcted.getAspspId());
-        assertEquals(result.getChargeBearer(), exepcted.getChargeBearer());
-        assertEquals(result.getCreditorAccount().getIdentification(), exepcted.getCreditorAccount().getIdentification());
-        assertEquals(result.getDebtorAccount().getIdentification(), exepcted.getDebtorAccount().getIdentification());
-        assertEquals(result.getCreditorName(), exepcted.getCreditorName());
-        assertEquals(result.getEndToEndId(), exepcted.getEndToEndId());
-        assertEquals(result.getInitiatingPartyReferenceId(), exepcted.getInitiatingPartyReferenceId());
-        assertEquals(result.getInitiatingPartyReturnUrl(), exepcted.getInitiatingPartyReturnUrl());
-        assertEquals(result.getPaymentAmount(), exepcted.getPaymentAmount());
-        assertEquals(result.getPaymentCurrency(), exepcted.getPaymentCurrency());
-        assertEquals(result.getPaymentProduct(), exepcted.getPaymentProduct());
-        assertEquals(result.getPreferredScaMethod(), exepcted.getPreferredScaMethod());
-        assertEquals(result.getPsuId(), exepcted.getPsuId());
-        assertEquals(result.getPsuSessionInformation().getHeaderUserAgent(), exepcted.getPsuSessionInformation().getHeaderUserAgent());
-        assertEquals(result.getPsuSessionInformation().getIpAddress(), exepcted.getPsuSessionInformation().getIpAddress());
-        assertEquals(result.getPurposeCode(), exepcted.getPurposeCode());
-        assertEquals(result.getRemittanceInformation(), exepcted.getRemittanceInformation());
-        assertEquals(result.getRemittanceInformationStructured().getReference(), exepcted.getRemittanceInformationStructured().getReference());
-        assertEquals(result.getRiskInformation().getChannelType(), exepcted.getRiskInformation().getChannelType());
-        assertEquals(result.getRiskInformation().getMerchantCategoryCode(), exepcted.getRiskInformation().getMerchantCategoryCode());
-        assertEquals(result.getRiskInformation().getMerchantCustomerId(), exepcted.getRiskInformation().getMerchantCustomerId());
-        assertEquals(result.getDebtorName(), exepcted.getDebtorName());
-        assertEquals(result.getInitiatingPartySubId(), exepcted.getInitiatingPartySubId());
-
-    }
-
-    @Test
-    void buildPaymentInitiationRequest_EmptyIBANForSpain() {
-        Psu psu = MockUtils.aPsu();
-        PaymentData paymentData = MockUtils.aPaymentDataBuilder()
-                .withIban("")
-                .build();
-        // create a genericPaymentRequest with an empty IBAN and a BIC from Spain
-        GenericPaymentRequest genericPaymentRequest = new GenericPaymentRequest(
-                MockUtils.aPaylinePaymentRequestBuilder().withPaymentFormContext(MockUtils.aPaymentFormContext(""))
-                        .build());
-
-        Assertions.assertThrows(InvalidDataException.class,
-                () -> service.buildPaymentInitiationRequest(genericPaymentRequest, psu, paymentData),
-                "IBAN is required for Spain"
-        );
-    }
-
-    @Test
-    void buildPaymentInitiationRequest_WrongIBAN() {
-        Psu psu = MockUtils.aPsu();
-        PaymentData paymentData = MockUtils.aPaymentDataBuilder()
-                .withIban("IT123456789")
-                .build();
-        // create a GenericPaymentRequest with an IBAN from a country not accepted, and the merchant lets all banks open
-        GenericPaymentRequest genericPaymentRequest = new GenericPaymentRequest(
-                MockUtils.aPaylinePaymentRequestBuilder()
-                        .withPaymentFormContext(MockUtils.aPaymentFormContext("IT123456789"))
-                        .withContractConfiguration(MockUtils.aContractConfiguration("TOUS"))
-                        .build());
-
-        Assertions.assertThrows(InvalidDataException.class,
-                () -> service.buildPaymentInitiationRequest(genericPaymentRequest, psu, paymentData),
-                "IBAN should be from a country available by the merchant "
-        );
-    }
-
-    @Test
-    void buildPaymentInitiationRequest_WrongCountryIBAN() {
-        Psu psu = MockUtils.aPsu();
-        PaymentData paymentData = MockUtils.aPaymentDataBuilder()
-                .withIban(MockUtils.getIbanES())
-                .build();
-        // create a GenericPaymentRequest with and IBAn from Spain, and the merchant only want it from France
-        GenericPaymentRequest genericPaymentRequest = new GenericPaymentRequest(
-                MockUtils.aPaylinePaymentRequestBuilder().withPaymentFormContext(MockUtils.aPaymentFormContext(MockUtils.getIbanES()))
-                        .build());
-
-        Assertions.assertThrows(InvalidDataException.class,
-                () -> service.buildPaymentInitiationRequest(genericPaymentRequest, psu, paymentData),
-                "IBAN should be from a country available by the merchant "
-        );
+        assertEquals("0.100", underTest.convertAmount(new Amount(BigInteger.valueOf(100), Currency.getInstance("BHD"))));
     }
 }

--- a/src/test/java/com/payline/payment/equens/service/impl/PaymentFormConfigurationServiceImplTest.java
+++ b/src/test/java/com/payline/payment/equens/service/impl/PaymentFormConfigurationServiceImplTest.java
@@ -100,24 +100,23 @@ class PaymentFormConfigurationServiceImplTest {
 
         final CustomForm customForm = (CustomForm) form;
         final List<PaymentFormField> customFields = customForm.getCustomFields();
-        assertEquals(4, customFields.size());
-        assertTrue(customFields.get(0) instanceof PaymentFormInputFieldIban);
+        assertEquals(3, customFields.size());
+        assertTrue(customFields.get(0) instanceof PaymentFormInputFieldSelect);
+        assertTrue(customFields.get(1) instanceof PaymentFormInputFieldSelect);
+        assertTrue(customFields.get(2) instanceof PaymentFormInputFieldIban);
 
-        final PaymentFormInputFieldIban ibanField = (PaymentFormInputFieldIban)customFields.get(0);
-        assertEquals(BankTransferForm.IBAN_KEY, ibanField.getKey());
-        assertTrue(customFields.get(1) instanceof PaymentFormDisplayFieldText);
-        assertTrue(customFields.get(2) instanceof PaymentFormInputFieldSelect);
-
-        final PaymentFormInputFieldSelect selectFields = (PaymentFormInputFieldSelect)customFields.get(2);
+        final PaymentFormInputFieldSelect selectFields = (PaymentFormInputFieldSelect)customFields.get(0);
         assertEquals(Constants.FormKeys.ASPSP_ID, selectFields.getKey());
         assertNotNull(selectFields.getSelectOptions());
         assertEquals(2, selectFields.getSelectOptions().size());
 
-        final PaymentFormInputFieldSelect selectSubsidiariesFields = (PaymentFormInputFieldSelect)customFields.get(3);
+        final PaymentFormInputFieldSelect selectSubsidiariesFields = (PaymentFormInputFieldSelect)customFields.get(1);
         assertEquals(Constants.FormKeys.SUB_ASPSP_ID, selectSubsidiariesFields.getKey());
         assertNotNull(selectSubsidiariesFields.getSelectOptions());
         assertEquals(0, selectSubsidiariesFields.getSelectOptions().size());
 
+        final PaymentFormInputFieldIban ibanField = (PaymentFormInputFieldIban)customFields.get(2);
+        assertEquals(BankTransferForm.IBAN_KEY, ibanField.getKey());
     }
 
     @Test
@@ -167,6 +166,9 @@ class PaymentFormConfigurationServiceImplTest {
 
         @Test
         void buildBankWithoutSubsidiary() {
+            final String expectedResult = "{ id : 'Axa Banque',\n" +
+                    " iban : false,  subList : []},{ id : 'La Banque Postale',\n" +
+                    " iban : false,  subList : []}";
             final Aspsp bank1 = new Aspsp();
             bank1.setCountryCode("FR");
             bank1.setName(Collections.singletonList("Axa Banque"));
@@ -182,7 +184,7 @@ class PaymentFormConfigurationServiceImplTest {
             final List<SelectOption> subsidiaryList = new ArrayList<>();
             final String result = underTest.buildBankScript(aspspList, primaryList, subsidiaryList);
             assertTrue(subsidiaryList.isEmpty());
-            assertEquals("", result);
+            assertEquals(expectedResult, result);
 
             final SelectOption bank1Option = primaryList.get(0);
             final SelectOption bank2Option = primaryList.get(1);
@@ -195,8 +197,10 @@ class PaymentFormConfigurationServiceImplTest {
 
         @Test
         void buildBankWithSubsidiary() {
-            final String expectedResult = "{ id : 'Crédit Agricole',\n" +
-                    "  subList : [{aspspId : '123', label : 'Crédit Agricole PACA'},{aspspId : '456', label : 'Crédit Agricole Paris'}]}";
+            final String expectedResult = "{ id : 'Axa Banque',\n" +
+                    " iban : false,  subList : []},{ id : 'Crédit Agricole',\n" +
+                    " iban : false,  subList : [{aspspId : '123', label : 'Crédit Agricole PACA',  iban : false}," +
+                    "{aspspId : '456', label : 'Crédit Agricole Paris',  iban : false}]}";
             final Aspsp bank1 = new Aspsp();
             bank1.setCountryCode("FR");
             bank1.setName(Collections.singletonList("Axa Banque"));


### PR DESCRIPTION
Gestion de l'IBAN Obligatoire si fichier SWIFT stipule DebtorAccount = Mandatory

- Modification du JQuery pour gérer les cas ou l'IBAN est demandé par les banques
- Modification au niveau du paiement pour vérifier si un aspspId a bien été initialisé et si le paiement requiert un iban ou non.